### PR TITLE
Add cooldown and rating tracking to survey prompt

### DIFF
--- a/src/surveyPrompt.ts
+++ b/src/surveyPrompt.ts
@@ -7,8 +7,11 @@ import { logger } from './logger';
 export class SurveyPrompt {
   private static readonly USAGE_COUNT_KEY = 'pick.usageCount';
   private static readonly SURVEY_DISMISSED_KEY = 'pick.surveyDismissed';
+  private static readonly SURVEY_RATED_KEY = 'pick.surveyRated';
   private static readonly REMIND_AT_KEY = 'pick.remindAt';
+  private static readonly LAST_SHOWN_KEY = 'pick.surveyLastShown';
   private static readonly USAGE_THRESHOLD = 3;
+  private static readonly SHOW_COOLDOWN = 3;
   private static readonly SURVEY_URL = 'https://brown.co1.qualtrics.com/jfe/form/SV_a90QURkTTwI9eHY';
   private static readonly MARKETPLACE_URL = 'https://marketplace.visualstudio.com/items?itemName=SiddharthaPrasad.pick-regex&ssr=false#review-details';
   
@@ -34,6 +37,13 @@ export class SurveyPrompt {
       return;
     }
 
+    // If the user has rated PICK, we never show the prompt again
+    const rated = this.context.globalState.get<boolean>(SurveyPrompt.SURVEY_RATED_KEY, false);
+    if (rated) {
+      logger.info('Survey prompt disabled because user already rated');
+      return;
+    }
+
     // Get current usage count
     const usageCount = this.context.globalState.get<number>(SurveyPrompt.USAGE_COUNT_KEY, 0);
     const newCount = usageCount + 1;
@@ -49,6 +59,13 @@ export class SurveyPrompt {
       return;
     }
 
+    // Enforce cooldown between prompts so we do not show the rate dialog on every run
+    const lastShown = this.context.globalState.get<number | undefined>(SurveyPrompt.LAST_SHOWN_KEY);
+    if (lastShown !== undefined && newCount < lastShown + SurveyPrompt.SHOW_COOLDOWN) {
+      logger.info(`Survey prompt last shown at ${lastShown}; waiting until ${lastShown + SurveyPrompt.SHOW_COOLDOWN} before showing again`);
+      return;
+    }
+
     // Show prompt when threshold is reached (at 3rd use or later if not yet shown)
     if (newCount >= SurveyPrompt.USAGE_THRESHOLD) {
       logger.info('Usage threshold reached, showing survey prompt');
@@ -60,8 +77,11 @@ export class SurveyPrompt {
    * Show the survey prompt to the user using VS Code's modal dialog
    */
   private async showSurveyPrompt(currentUsage?: number): Promise<void> {
+    const usage = typeof currentUsage === 'number' ? currentUsage : this.context.globalState.get<number>(SurveyPrompt.USAGE_COUNT_KEY, 0);
+    await this.context.globalState.update(SurveyPrompt.LAST_SHOWN_KEY, usage);
+
     const message = 'PICK is a research tool. It helps us justify it to our funders if we can show some user feedback. Would you help us by completing a very short, quick survey and/or by rating us?';
-    
+
     const surveyOption = 'Share Feedback';
     const rateOption = 'Rate Extension';
     const remindOption = 'Remind Me Later';
@@ -90,6 +110,7 @@ export class SurveyPrompt {
       await vscode.env.openExternal(vscode.Uri.parse(SurveyPrompt.MARKETPLACE_URL));
       // Mark as dismissed so we don't show it again
       await this.context.globalState.update(SurveyPrompt.SURVEY_DISMISSED_KEY, true);
+      await this.context.globalState.update(SurveyPrompt.SURVEY_RATED_KEY, true);
       await this.context.globalState.update(SurveyPrompt.REMIND_AT_KEY, undefined);
     } else if (choice === dontAskOption) {
       // Mark as dismissed permanently
@@ -114,7 +135,9 @@ export class SurveyPrompt {
   async resetUsageTracking(): Promise<void> {
     await this.context.globalState.update(SurveyPrompt.USAGE_COUNT_KEY, 0);
     await this.context.globalState.update(SurveyPrompt.SURVEY_DISMISSED_KEY, false);
+    await this.context.globalState.update(SurveyPrompt.SURVEY_RATED_KEY, false);
     await this.context.globalState.update(SurveyPrompt.REMIND_AT_KEY, undefined);
+    await this.context.globalState.update(SurveyPrompt.LAST_SHOWN_KEY, undefined);
     logger.info('Reset usage tracking');
   }
 }


### PR DESCRIPTION
## Summary
- prevent the survey prompt from showing if the user has already rated the extension
- add a three-use cooldown after showing the prompt so it is not displayed on every run
- track and reset new survey prompt state keys, including the last shown usage count

## Testing
- Not run (npm/node not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693311a8b19c832c88831214dcd17b8e)