### PR TITLE
Log user prompt in regex generation logs

### DIFF
--- a/src/regexService.ts
+++ b/src/regexService.ts
@@ -159,6 +159,8 @@ export async function generateRegexFromDescription(
   token: vscode.CancellationToken,
   modelId?: string
 ): Promise<RegexGenerationResult> {
+  logger.info(`User prompt: ${description}`);
+
   // Get available language models
   const models = await vscode.lm.selectChatModels({});
 


### PR DESCRIPTION
## Summary
- add logging to capture the user prompt when generating regex candidates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693763eb3314832c9b059978e8ce287a)