### PR TITLE
Persist selected model across sessions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
 	const surveyPrompt = new SurveyPrompt(context);
 
 	// Register the PICK webview provider
-	const provider = new PickViewProvider(context.extensionUri, surveyPrompt);
+        const provider = new PickViewProvider(context.extensionUri, surveyPrompt, context.globalState);
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(PickViewProvider.viewType, provider)
 	);
@@ -23,11 +23,11 @@ export function activate(context: vscode.ExtensionContext) {
 		await openIssueReport();
 	});
 
-	const resetSurveyCommand = vscode.commands.registerCommand('pick.resetSurveyState', async () => {
-		await surveyPrompt.resetUsageTracking();
-		provider.resetLocalWebviewState();
-		vscode.window.showInformationMessage('PICK local storage, history, and splash preference have been cleared.');
-	});
+        const resetSurveyCommand = vscode.commands.registerCommand('pick.resetSurveyState', async () => {
+                await surveyPrompt.resetUsageTracking();
+                await provider.resetLocalWebviewState();
+                vscode.window.showInformationMessage('PICK local storage, history, and splash preference have been cleared.');
+        });
 
 	context.subscriptions.push(reportIssueCommand, resetSurveyCommand);
 }


### PR DESCRIPTION
## Summary
- store the preferred chat model selection in extension global state and reuse it when loading available models
- update the webview model selector to preselect the saved model when available and notify the extension on user changes
- ensure resetting local state also clears the saved model preference

## Testing
- npm test *(fails: unable to download VS Code test assets due to network JSON parse error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d8ee1dca8832cad3d0ed01958ee44)