### PR TITLE
Add set relationship visual tab

### DIFF
--- a/media/pickView.css
+++ b/media/pickView.css
@@ -659,6 +659,116 @@
             line-height: 1;
         }
 
+        .candidate-tablist {
+            display: flex;
+            gap: 6px;
+            border-bottom: 1px solid var(--vscode-panel-border);
+            padding-bottom: 6px;
+            margin-bottom: 10px;
+        }
+
+        .candidate-tab {
+            background: transparent;
+            border: 1px solid transparent;
+            color: var(--vscode-foreground);
+            padding: 6px 10px;
+            border-radius: 4px 4px 0 0;
+            cursor: pointer;
+            font-weight: 500;
+        }
+
+        .candidate-tab.active {
+            border-color: var(--vscode-panel-border);
+            border-bottom-color: transparent;
+            background: var(--vscode-editor-background);
+        }
+
+        .candidate-panels {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .candidate-tabpanel {
+            display: none;
+        }
+
+        .candidate-tabpanel.active {
+            display: block;
+        }
+
+        .candidate-item--winner {
+            border: 2px solid var(--pick-accept-color);
+            background: color-mix(in srgb, var(--pick-accept-color) 10%, var(--pick-regex-surface));
+        }
+
+        .btn--winner {
+            border: 1px solid var(--pick-accept-color);
+        }
+
+        .candidate-section-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+        }
+
+        .relationship-legend {
+            font-size: 12px;
+            color: var(--vscode-descriptionForeground);
+            margin-bottom: 6px;
+        }
+
+        .relationship-card {
+            border: 1px solid var(--vscode-panel-border);
+            border-radius: 6px;
+            padding: 8px;
+            margin-bottom: 8px;
+            background: var(--pick-regex-surface);
+        }
+
+        .relationship-summary {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-items: center;
+            margin-bottom: 4px;
+        }
+
+        .relationship-label {
+            font-weight: 600;
+            color: var(--vscode-foreground);
+        }
+
+        .relationship-patterns {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            flex-wrap: wrap;
+            font-family: monospace;
+        }
+
+        .relationship-arrow {
+            opacity: 0.7;
+        }
+
+        .relationship-detail {
+            color: var(--vscode-descriptionForeground);
+            margin-bottom: 6px;
+        }
+
+        .relationship-counts {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 6px;
+            font-size: 12px;
+        }
+
+        .relationship-empty {
+            color: var(--vscode-descriptionForeground);
+            font-style: italic;
+        }
+
 
         .equivalent-toggle {
             padding: 6px 8px;

--- a/media/pickView.css
+++ b/media/pickView.css
@@ -754,14 +754,100 @@
 
         .relationship-detail {
             color: var(--vscode-descriptionForeground);
-            margin-bottom: 6px;
+            margin-bottom: 10px;
         }
 
-        .relationship-counts {
+        .relationship-venn {
+            position: relative;
+            height: 140px;
+            margin-bottom: 12px;
+        }
+
+        .relationship-venn-circle {
+            position: absolute;
+            width: 160px;
+            height: 120px;
+            border-radius: 50%;
+            background: color-mix(in srgb, var(--vscode-tab-activeForeground) 10%, transparent);
+            border: 1px solid color-mix(in srgb, var(--vscode-tab-activeForeground) 20%, transparent);
+            top: 10px;
+        }
+
+        .relationship-venn-circle-a {
+            left: 10px;
+            background: color-mix(in srgb, var(--pick-accept-color) 14%, transparent);
+            border-color: color-mix(in srgb, var(--pick-accept-color) 40%, transparent);
+        }
+
+        .relationship-venn-circle-b {
+            right: 10px;
+            background: color-mix(in srgb, var(--pick-reject-color) 14%, transparent);
+            border-color: color-mix(in srgb, var(--pick-reject-color) 40%, transparent);
+        }
+
+        .relationship-venn-label {
+            position: absolute;
+            font-size: 12px;
+            color: var(--vscode-foreground);
+            padding: 4px 6px;
+            border-radius: 4px;
+            background: color-mix(in srgb, var(--pick-regex-surface) 75%, transparent);
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+            max-width: 120px;
+        }
+
+        .relationship-venn-label-a {
+            left: 24px;
+            top: 18px;
+        }
+
+        .relationship-venn-label-b {
+            right: 24px;
+            top: 18px;
+            text-align: right;
+        }
+
+        .relationship-venn-label-overlap {
+            left: 50%;
+            transform: translateX(-50%);
+            bottom: 16px;
+            text-align: center;
+            background: color-mix(in srgb, var(--vscode-editorHoverWidget-background) 80%, transparent);
+        }
+
+        .relationship-example-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-            gap: 6px;
+            gap: 8px;
+        }
+
+        .relationship-example {
+            border: 1px solid var(--vscode-panel-border);
+            border-radius: 6px;
+            padding: 6px;
+            background: color-mix(in srgb, var(--pick-regex-surface) 70%, transparent);
+        }
+
+        .relationship-example-title {
+            font-weight: 600;
+            margin-bottom: 4px;
             font-size: 12px;
+        }
+
+        .relationship-example-list {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+            display: grid;
+            gap: 3px;
+            font-family: var(--pick-font-mono);
+            word-break: break-word;
+            font-size: 12px;
+        }
+
+        .relationship-example-empty {
+            color: var(--vscode-descriptionForeground);
+            font-style: italic;
         }
 
         .relationship-empty {

--- a/media/pickView.js
+++ b/media/pickView.js
@@ -1600,8 +1600,37 @@
 
             const legend = document.createElement('div');
             legend.className = 'relationship-legend';
-            legend.textContent = 'Set relationships are estimated from pairwise comparisons between candidates.';
+            legend.textContent = 'Pairwise comparisons include small witness sets inspired by regex-utils\' equivalence checker.';
             panel.appendChild(legend);
+
+            const buildExampleColumn = (title, items, modifier) => {
+                const column = document.createElement('div');
+                column.className = `relationship-example ${modifier || ''}`.trim();
+
+                const heading = document.createElement('div');
+                heading.className = 'relationship-example-title';
+                heading.textContent = title;
+                column.appendChild(heading);
+
+                const list = document.createElement('ul');
+                list.className = 'relationship-example-list';
+
+                if (Array.isArray(items) && items.length > 0) {
+                    items.slice(0, 5).forEach(item => {
+                        const li = document.createElement('li');
+                        li.textContent = item;
+                        list.appendChild(li);
+                    });
+                } else {
+                    const li = document.createElement('li');
+                    li.className = 'relationship-example-empty';
+                    li.textContent = 'No witness found';
+                    list.appendChild(li);
+                }
+
+                column.appendChild(list);
+                return column;
+            };
 
             relationships.forEach(function(rel) {
                 const card = document.createElement('div');
@@ -1627,14 +1656,44 @@
                 detail.textContent = description.description;
                 card.appendChild(detail);
 
-                if (rel.countANotB || rel.countBNotA) {
-                    const counts = document.createElement('div');
-                    counts.className = 'relationship-counts';
-                    counts.innerHTML =
-                        `<div><strong>A \ B:</strong> ${formatRelationshipCount(rel.countANotB)}</div>` +
-                        `<div><strong>B \ A:</strong> ${formatRelationshipCount(rel.countBNotA)}</div>`;
-                    card.appendChild(counts);
-                }
+                const venn = document.createElement('div');
+                venn.className = 'relationship-venn';
+
+                const circleA = document.createElement('div');
+                circleA.className = 'relationship-venn-circle relationship-venn-circle-a';
+                const circleB = document.createElement('div');
+                circleB.className = 'relationship-venn-circle relationship-venn-circle-b';
+
+                const countA = document.createElement('div');
+                countA.className = 'relationship-venn-label relationship-venn-label-a';
+                countA.textContent = `A \\ B: ${formatRelationshipCount(rel.countANotB)}`;
+
+                const countOverlap = document.createElement('div');
+                countOverlap.className = 'relationship-venn-label relationship-venn-label-overlap';
+                const overlapExamples = Array.isArray(rel.examplesBoth) ? rel.examplesBoth : [];
+                countOverlap.textContent = overlapExamples.length > 0
+                    ? `Shared sample: ${overlapExamples[0]}`
+                    : 'Shared region';
+
+                const countB = document.createElement('div');
+                countB.className = 'relationship-venn-label relationship-venn-label-b';
+                countB.textContent = `B \\ A: ${formatRelationshipCount(rel.countBNotA)}`;
+
+                venn.appendChild(circleA);
+                venn.appendChild(circleB);
+                venn.appendChild(countA);
+                venn.appendChild(countOverlap);
+                venn.appendChild(countB);
+
+                card.appendChild(venn);
+
+                const exampleGrid = document.createElement('div');
+                exampleGrid.className = 'relationship-example-grid';
+                exampleGrid.appendChild(buildExampleColumn('Only A', rel.examplesANotB, 'a'));
+                exampleGrid.appendChild(buildExampleColumn('Shared (A ∩ B)', rel.examplesBoth, 'overlap'));
+                exampleGrid.appendChild(buildExampleColumn('Only B', rel.examplesBNotA, 'b'));
+
+                card.appendChild(exampleGrid);
 
                 panel.appendChild(card);
             });

--- a/src/pickViewProvider.ts
+++ b/src/pickViewProvider.ts
@@ -440,9 +440,12 @@ export class PickViewProvider implements vscode.WebviewViewProvider {
         return;
       }
 
+      const status = this.controller.getStatus();
       this.sendMessage({
         type: 'candidatesGenerated',
-        candidates: this.controller.getStatus().candidateDetails
+        candidates: status.candidateDetails,
+        candidateRelationships: status.candidateRelationships,
+        threshold: status.threshold
       });
 
       // Check cancellation before generating first pair
@@ -1007,9 +1010,12 @@ export class PickViewProvider implements vscode.WebviewViewProvider {
         return;
       }
 
+      const status = this.controller.getStatus();
       this.sendMessage({
         type: 'candidatesRefined',
-        candidates: this.controller.getStatus().candidateDetails,
+        candidates: status.candidateDetails,
+        candidateRelationships: status.candidateRelationships,
+        threshold: status.threshold,
         preservedClassifications: sessionData.wordHistory.length
       });
 

--- a/src/test/pickController.test.ts
+++ b/src/test/pickController.test.ts
@@ -823,6 +823,10 @@ suite('PickController Test Suite', () => {
         assert.strictEqual(letterVsAlnum.relation, 'superset');
       }
 
+      assert.ok(Array.isArray(letterVsAlnum?.examplesANotB), 'Should expose witness examples for A \\ B');
+      assert.ok(Array.isArray(letterVsAlnum?.examplesBNotA), 'Should expose witness examples for B \\ A');
+      assert.ok(Array.isArray(letterVsAlnum?.examplesBoth), 'Should expose shared witness examples');
+
       const alnumVsDigits = relationships.find(rel =>
         (rel.a === '[a-z0-9]+' && rel.b === '[0-9]+') ||
         (rel.a === '[0-9]+' && rel.b === '[a-z0-9]+')
@@ -834,6 +838,10 @@ suite('PickController Test Suite', () => {
       } else if (alnumVsDigits) {
         assert.strictEqual(alnumVsDigits.relation, 'subset');
       }
+
+      assert.ok(Array.isArray(alnumVsDigits?.examplesANotB), 'Should expose witness examples for A \\ B');
+      assert.ok(Array.isArray(alnumVsDigits?.examplesBNotA), 'Should expose witness examples for B \\ A');
+      assert.ok(Array.isArray(alnumVsDigits?.examplesBoth), 'Should expose shared witness examples');
     });
   });
 


### PR DESCRIPTION
## Summary
- track pairwise set relationships between candidate regexes and surface them in status updates
- add a relationships tab in the webview to visualize overlaps and subsets alongside the candidate list
- style the new view and add coverage for candidate relationship reporting
- ensure every pairwise relationship is computed during threshold determination so the UI receives the full matrix

## Testing
- npm run compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693db2f6552c832c968300a5309b5012)