### PR TITLE
Add repository-wide agent guidelines for testing and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Guidelines
+
+## Scope
+These instructions apply to the entire repository.
+
+## Testing and documentation expectations
+- Every change must be accompanied by an automated test when feasible. If a test cannot be added, record the manual verification performed in the `manual-testing/` directory (add a new markdown file or update an existing one).
+- Avoid updating `README.md` for documentation changes. Add supporting notes to relevant files or to `manual-testing/` instead.
+
+## PR and review hygiene
+- Keep changes small and focused. Include context in commit messages when tests are intentionally omitted.


### PR DESCRIPTION
## Summary
- add AGENTS.md with repository-wide instructions
- require pairing changes with tests or manual testing notes
- direct documentation updates away from README and into manual-testing when needed

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694180888384832cb8a3afe03fa44c6f)